### PR TITLE
Fixed redirect to prevent false positives

### DIFF
--- a/geoip.php
+++ b/geoip.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: John Gamboa's GeoTarget Redirect Example
 Description: Redirecting visitor traffic based on geo-location using the WPEngine GeoTarget feature
-Version: 1.1
+Version: 1.2
 License: GPLv2
 */
 
@@ -10,19 +10,19 @@ function country_geo_redirect() {
 
 $country = getenv('HTTP_GEOIP_COUNTRY_CODE');
 
-if ( $country == "US" ) {
+if ( $country == 'US' ) {
 
 wp_redirect( 'https://en.wikipedia.org/wiki/United_States', 301 );
 
      exit;
 
-} else if ( $country == "BR" ) {
+} else if ( $country == 'BR' ) {
 
 wp_redirect( 'https://en.wikipedia.org/wiki/Brazil', 301 );
 
      exit;
 
-}else if ( $country !== "(US|BR)" ) {
+}else if ( $country !==  ( 'US' || 'BR' ) ) {
 
 wp_redirect( 'https://en.wikipedia.org/wiki/Earth', 301 );
 


### PR DESCRIPTION
# Issue
While testing the plugin on base installs, I ran into an issue where it persistently redirected me to the Earth page, even when connecting from a US. Initially this was resolved when changing the last `else if` statement's comparison operator. Further investigation and troubleshooting indicating the problem may be with the actual statement being checked:

```
else if ( $country !== "(US|BR)" )
```

The above was specifically checking for the string `(US|BR)` as opposed to the country code `US` *or* `BR`. Adjusting it to the following resolved the issue:

```
else if ( $country !== ('US' || 'BR') )
```

# Testing
Testing completed on personal site and now works as expected. Testing with Ireland as opposed to Brazil as no access to Brazilian VPN.